### PR TITLE
feat: ism policy mapping should work with existing policies

### DIFF
--- a/modules/ingestion/pipeline/data.tf
+++ b/modules/ingestion/pipeline/data.tf
@@ -5,6 +5,7 @@ data "aws_caller_identity" "current" {}
 data "aws_iam_policy_document" "cloudwatch" {
   #checkov:skip=CKV_AWS_283=Ensure no IAM policies documents allow ALL or any AWS principal permissions to the resource
   #checkov:skip=CKV_AWS_111=Ensure IAM policies does not allow write access without constraints
+  #checkov:skip=CKV_AWS_356=Ensure IAM policies limit resource access
   statement {
     sid = "Add permission for cloudwatch log group to access KMS key"
 

--- a/modules/resource-mgt/ism.tf
+++ b/modules/resource-mgt/ism.tf
@@ -1,17 +1,24 @@
 resource "elasticsearch_opensearch_ism_policy" "this" {
-  for_each = nonsensitive(var.ism_policies)
+  for_each = nonsensitive(local.new_ism_policies)
 
   policy_id = each.key
-  body      = each.value
+  body      = each.value.body
 }
 
-resource "elasticsearch_opensearch_ism_policy_mapping" "this" {
-  for_each = nonsensitive(var.ism_policies)
+resource "elasticsearch_opensearch_ism_policy_mapping" "new_policies" {
+  for_each = nonsensitive(local.new_ism_policies)
 
   policy_id = each.key
-  indexes   = var.ism_index_pattern
+  indexes   = each.value.ism_index_pattern
 
   depends_on = [
     elasticsearch_opensearch_ism_policy.this
   ]
+}
+
+resource "elasticsearch_opensearch_ism_policy_mapping" "existing_policies" {
+  for_each = nonsensitive(local.existing_ism_policies)
+
+  policy_id = each.key
+  indexes   = each.value.ism_index_pattern
 }

--- a/modules/resource-mgt/locals.tf
+++ b/modules/resource-mgt/locals.tf
@@ -1,0 +1,7 @@
+locals {
+  # Filter out ISM policies that require creation
+  new_ism_policies = { for k, v in var.ism_policies : k => v if v.create }
+
+  # Filter out ISM policies that are pre-existing
+  existing_ism_policies = { for k, v in var.ism_policies : k => v if v.create == false }
+}

--- a/modules/resource-mgt/variables.tf
+++ b/modules/resource-mgt/variables.tf
@@ -4,10 +4,10 @@ variable "domain_endpoint" {
 }
 
 variable "ism_policies" {
-  description = "A map of all ISM policies to create. Body should be json encoded"
+  description = "A map of all ISM policies. Body should be json encoded"
   type = map(object({
     create            = bool
-    body              = string
+    body              = optional(string)
     ism_index_pattern = string
   }))
   default = {}

--- a/modules/resource-mgt/variables.tf
+++ b/modules/resource-mgt/variables.tf
@@ -4,13 +4,11 @@ variable "domain_endpoint" {
 }
 
 variable "ism_policies" {
-  description = "A map of all ISM policies to create. Value should be json encoded"
-  type        = map(string)
-  default     = {}
-}
-
-variable "ism_index_pattern" {
-  description = "Index pattern to apply ISM policies to"
-  type        = string
-  default     = null
+  description = "A map of all ISM policies to create. Body should be json encoded"
+  type = map(object({
+    create            = bool
+    body              = string
+    ism_index_pattern = string
+  }))
+  default = {}
 }


### PR DESCRIPTION
We want to have the ability to map ISM policies to indices in cases where an ISM policy already exists. This enables us to do that. It is observed that in some situations the ISM policy creation API call times out but the policy does get created. This can also help us there too. 