### PR TITLE
fix: elasticsearch v7.8+ uses new ism template api

### DIFF
--- a/modules/ism/template/README.md
+++ b/modules/ism/template/README.md
@@ -19,7 +19,7 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [opensearch_index_template.this](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/index_template) | resource |
+| [opensearch_composable_index_template.this](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/composable_index_template) | resource |
 
 ## Inputs
 

--- a/modules/ism/template/main.tf
+++ b/modules/ism/template/main.tf
@@ -1,4 +1,4 @@
-resource "opensearch_index_template" "this" {
+resource "opensearch_composable_index_template" "this" {
   name = var.name
   body = var.body
 }

--- a/modules/ism/template/ouputs.tf
+++ b/modules/ism/template/ouputs.tf
@@ -1,4 +1,4 @@
 output "id" {
   description = "The ID of the index template"
-  value       = opensearch_index_template.this.id
+  value       = opensearch_composable_index_template.this.id
 }


### PR DESCRIPTION
Elasticsearch v7.8 onwards uses the `_index_template` API which is relatively newer. We are switching the resource type for ISM template to make it compatible with Opensearch

https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/composable_index_template