### PR TITLE
add additional options for auto tune

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ resource "aws_opensearch_domain" "this" {
     desired_state       = var.auto_tune_desired_state
     rollback_on_disable = var.rollback_on_disable
     dynamic "maintenance_schedule" {
-      for_each = var.maintenance_schedule != null ? var.maintenance_schedule : {}
+      for_each = var.maintenance_schedule
       content {
         start_at = maintenance_schedule.start_at
         duration {

--- a/main.tf
+++ b/main.tf
@@ -91,8 +91,21 @@ resource "aws_opensearch_domain" "this" {
   }
 
   auto_tune_options {
-    desired_state = var.auto_tune_desired_state
+    desired_state       = var.auto_tune_desired_state
+    rollback_on_disable = var.rollback_on_disable
+    dynamic "maintenance_schedule" {
+      for_each = var.maintenance_schedule != null ? var.maintenance_schedule : {}
+      content {
+        start_at = maintenance_schedule.start_at
+        duration {
+          value = maintenance_schedule.duration
+          unit  = "HOURS"
+        }
+        cron_expression_for_recurrence = maintenance_schedule.cron_expression_for_recurrence
+      }
+    }
   }
+
 
   tags = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -343,3 +343,15 @@ variable "auto_tune_desired_state" {
   type        = string
   default     = "ENABLED"
 }
+
+variable "rollback_on_disable" {
+  description = "whether to roll back auto tune if auto tune is disabled"
+  type        = string
+  default     = "NO_ROLLBACK"
+}
+
+variable "maintenance_schedule" {
+  description = "configuration for auto tune maintenance schedule"
+  type        = map(any)
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -353,5 +353,5 @@ variable "rollback_on_disable" {
 variable "maintenance_schedule" {
   description = "configuration for auto tune maintenance schedule"
   type        = map(any)
-  default     = null
+  default     = {}
 }


### PR DESCRIPTION
additional auto tune options is required to create new opensearch domains. If `rollback_on_disable` is not declared, terraform apply will have the following issue:

`Error: modifying config for OpenSearch Domain: ValidationException: 1 validation error detected: Value '' at 'autoTuneOptions.rollbackOnDisable' failed to satisfy constraint: Member must satisfy enum value set: [DEFAULT_ROLLBACK, NO_ROLLBACK]`

`rollback_on_disable` also requires `maintenance_window` if `DEFAULT_ROLLBACK` is selected, so added as a dynamic block