### PR TITLE
chore: remove deprecated kibana endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,4 +98,3 @@ No modules.
 | <a name="output_domain_endpoint"></a> [domain\_endpoint](#output\_domain\_endpoint) | Domain-specific endpoint used to submit index, search, and data upload requests |
 | <a name="output_domain_id"></a> [domain\_id](#output\_domain\_id) | Unique identifier for the Cluster |
 | <a name="output_domain_name"></a> [domain\_name](#output\_domain\_name) | Name of the OpenSearch Cluster |
-| <a name="output_kibana_endpoint"></a> [kibana\_endpoint](#output\_kibana\_endpoint) | Domain-specific endpoint for kibana without https scheme. |

--- a/examples/opensearch/outputs.tf
+++ b/examples/opensearch/outputs.tf
@@ -17,8 +17,3 @@ output "domain_endpoint" {
   description = "Domain-specific endpoint used to submit index, search, and data upload requests"
   value       = module.opensearch.domain_endpoint
 }
-
-output "kibana_endpoint" {
-  description = "Domain-specific endpoint for kibana without https scheme."
-  value       = module.opensearch.kibana_endpoint
-}

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,8 +17,3 @@ output "domain_endpoint" {
   description = "Domain-specific endpoint used to submit index, search, and data upload requests"
   value       = aws_opensearch_domain.this.endpoint
 }
-
-output "kibana_endpoint" {
-  description = "Domain-specific endpoint for kibana without https scheme."
-  value       = aws_opensearch_domain.this.kibana_endpoint
-}


### PR DESCRIPTION
Opensearch does not use Kibana and this field has been deprecated so it can be removed