### PR TITLE
restricted iam policy for ingestion pipeline

### DIFF
--- a/modules/ingestion/iam/data.tf
+++ b/modules/ingestion/iam/data.tf
@@ -7,8 +7,14 @@ data "aws_iam_policy_document" "opensearch_ingestion" {
   }
 
   statement {
-    effect    = "Allow"
-    actions   = ["es:ESHttp*"]
+    effect = "Allow"
+    actions = [
+      "es:ESHttpGet",
+      "es:ESHttpHead",
+      "es:ESHttpPatch",
+      "es:ESHttpPost",
+      "es:ESHttpPut",
+    ]
     resources = [for domain in var.opensearch_domain_arns : "${domain}/*"]
   }
 }


### PR DESCRIPTION
Ingestion pipeline IAM role only needs read/write permissions to Opensearch