### PR TITLE
support for buffering in ingestion pipelines

### DIFF
--- a/examples/ingestion/main.tf
+++ b/examples/ingestion/main.tf
@@ -31,4 +31,6 @@ module "ingestion_pipeline" {
 
   iam_role_name      = module.ingestion_iam.pipeline_role_name
   configuration_body = templatefile("./pipeline.yaml", local.pipeline_values)
+
+  persistent_buffer_enabled = true # false by default
 }

--- a/modules/ingestion/pipeline/README.md
+++ b/modules/ingestion/pipeline/README.md
@@ -4,7 +4,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.38 |
-| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.52 |
+| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.67 |
 
 ## Providers
 
@@ -44,6 +44,7 @@
 | <a name="input_max_units"></a> [max\_units](#input\_max\_units) | The maximum pipeline capacity, in Ingestion Compute Units | `number` | n/a | yes |
 | <a name="input_min_units"></a> [min\_units](#input\_min\_units) | The minimum pipeline capacity, in Ingestion Compute Units | `number` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of the ingestion pipeline | `string` | n/a | yes |
+| <a name="input_persistent_buffer_enabled"></a> [persistent\_buffer\_enabled](#input\_persistent\_buffer\_enabled) | Whether persistent buffering should be enabled | `bool` | `false` | no |
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Security group IDs to attach to the pipeline | `list(string)` | `[]` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to deploy pipeline in. Only needed if pipeline is to be deployed in VPC mode | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |

--- a/modules/ingestion/pipeline/pipeline.tf
+++ b/modules/ingestion/pipeline/pipeline.tf
@@ -14,6 +14,10 @@ resource "awscc_osis_pipeline" "this" {
     }
   }
 
+  buffer_options = {
+    persistent_buffer_enabled = var.persistent_buffer_enabled
+  }
+
   tags = local.pipeline_tags
 
   depends_on = [

--- a/modules/ingestion/pipeline/variables.tf
+++ b/modules/ingestion/pipeline/variables.tf
@@ -41,6 +41,12 @@ variable "security_group_ids" {
   default     = []
 }
 
+variable "persistent_buffer_enabled" {
+  description = "Whether persistent buffering should be enabled"
+  type        = bool
+  default     = false
+}
+
 variable "log_group_retention_days" {
   description = "Duration in days for cloudwatch log group retention"
   type        = number

--- a/modules/ingestion/pipeline/versions.tf
+++ b/modules/ingestion/pipeline/versions.tf
@@ -8,7 +8,7 @@ terraform {
     }
     awscc = {
       source  = "hashicorp/awscc"
-      version = ">= 0.52"
+      version = ">= 0.67"
     }
   }
 }


### PR DESCRIPTION
Opensearch ingestion pipelines now support buffering.

References: 
- https://aws.amazon.com/blogs/big-data/introducing-persistent-buffering-for-amazon-opensearch-ingestion/
- https://registry.terraform.io/providers/hashicorp/awscc/0.67.0/docs/resources/osis_pipeline#nested-schema-for-buffer_options