### PR TITLE
migrate osis pipeline to aws from awscc

### DIFF
--- a/examples/ingestion/versions.tf
+++ b/examples/ingestion/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.15"
-    }
-    awscc = {
-      source  = "hashicorp/awscc"
-      version = "~> 0.60"
+      version = "~> 5.36"
     }
   }
 }

--- a/modules/ingestion/pipeline/README.md
+++ b/modules/ingestion/pipeline/README.md
@@ -3,15 +3,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.38 |
-| <a name="requirement_awscc"></a> [awscc](#requirement\_awscc) | >= 0.67 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.36 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
-| <a name="provider_awscc"></a> [awscc](#provider\_awscc) | 0.52.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.36.0 |
 
 ## Modules
 
@@ -26,7 +24,7 @@
 | [aws_cloudwatch_log_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_log_group) | resource |
 | [aws_iam_policy.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role_policy_attachment.cloudwatch](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [awscc_osis_pipeline.this](https://registry.terraform.io/providers/hashicorp/awscc/latest/docs/resources/osis_pipeline) | resource |
+| [aws_osis_pipeline.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/osis_pipeline) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_default_tags.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/default_tags) | data source |
 | [aws_iam_policy_document.cloudwatch_log_group](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -45,8 +43,8 @@
 | <a name="input_min_units"></a> [min\_units](#input\_min\_units) | The minimum pipeline capacity, in Ingestion Compute Units | `number` | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | Name of the ingestion pipeline | `string` | n/a | yes |
 | <a name="input_persistent_buffer_enabled"></a> [persistent\_buffer\_enabled](#input\_persistent\_buffer\_enabled) | Whether persistent buffering should be enabled | `bool` | `false` | no |
-| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Security group IDs to attach to the pipeline | `list(string)` | `[]` | no |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to deploy pipeline in. Only needed if pipeline is to be deployed in VPC mode | `list(string)` | `[]` | no |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Security group IDs to attach to the pipeline | `list(string)` | `null` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to deploy pipeline in. Only needed if pipeline is to be deployed in VPC mode | `list(string)` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/modules/ingestion/pipeline/README.md
+++ b/modules/ingestion/pipeline/README.md
@@ -35,17 +35,17 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_configuration_body"></a> [configuration\_body](#input\_configuration\_body) | The Data Prepper pipeline configuration in YAML format | `string` | n/a | yes |
-| <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | If true, will create a cloudwatch log group to monitor the pipeline | `bool` | `true` | no |
-| <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name of the pipeline IAM role | `string` | n/a | yes |
-| <a name="input_log_group_retention_days"></a> [log\_group\_retention\_days](#input\_log\_group\_retention\_days) | Duration in days for cloudwatch log group retention | `number` | `30` | no |
-| <a name="input_max_units"></a> [max\_units](#input\_max\_units) | The maximum pipeline capacity, in Ingestion Compute Units | `number` | n/a | yes |
-| <a name="input_min_units"></a> [min\_units](#input\_min\_units) | The minimum pipeline capacity, in Ingestion Compute Units | `number` | n/a | yes |
-| <a name="input_name"></a> [name](#input\_name) | Name of the ingestion pipeline | `string` | n/a | yes |
+| <a name="input_configuration_body"></a> [configuration\_body](#input\_configuration\_body) | The Data Prepper pipeline configuration in YAML format | `string` | n/a     | yes |
+| <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | If true, will create a cloudwatch log group to monitor the pipeline | `bool` | `true`  | no |
+| <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name of the pipeline IAM role | `string` | n/a     | yes |
+| <a name="input_log_group_retention_days"></a> [log\_group\_retention\_days](#input\_log\_group\_retention\_days) | Duration in days for cloudwatch log group retention | `number` | `30`    | no |
+| <a name="input_max_units"></a> [max\_units](#input\_max\_units) | The maximum pipeline capacity, in Ingestion Compute Units | `number` | n/a     | yes |
+| <a name="input_min_units"></a> [min\_units](#input\_min\_units) | The minimum pipeline capacity, in Ingestion Compute Units | `number` | n/a     | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the ingestion pipeline | `string` | n/a     | yes |
 | <a name="input_persistent_buffer_enabled"></a> [persistent\_buffer\_enabled](#input\_persistent\_buffer\_enabled) | Whether persistent buffering should be enabled | `bool` | `false` | no |
-| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Security group IDs to attach to the pipeline | `list(string)` | `null` | no |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to deploy pipeline in. Only needed if pipeline is to be deployed in VPC mode | `list(string)` | `null` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Security group IDs to attach to the pipeline | `list(string)` | `[]`    | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to deploy pipeline in. Only needed if pipeline is to be deployed in VPC mode | `list(string)` | `[]`    | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}`    | no |
 
 ## Outputs
 

--- a/modules/ingestion/pipeline/locals.tf
+++ b/modules/ingestion/pipeline/locals.tf
@@ -3,14 +3,4 @@ locals {
   region     = data.aws_region.current.name
 
   pipeline_log_group = "/aws/vendedlogs/OpenSearchIngestion/${var.name}/audit-logs"
-
-  vpc_options = length(var.subnet_ids) > 0 ? {
-    subnet_ids         = var.subnet_ids
-    security_group_ids = var.security_group_ids
-  } : null
-
-  pipeline_tags = [for k, v in merge(var.tags, data.aws_default_tags.this.tags) : {
-    key   = k
-    value = v
-  }]
 }

--- a/modules/ingestion/pipeline/outputs.tf
+++ b/modules/ingestion/pipeline/outputs.tf
@@ -1,14 +1,14 @@
 output "id" {
   description = "ID of the ingestion pipeline"
-  value       = awscc_osis_pipeline.this.id
+  value       = aws_osis_pipeline.this.id
 }
 
 output "arn" {
   description = "ARN of the ingestion pipeline"
-  value       = awscc_osis_pipeline.this.pipeline_arn
+  value       = aws_osis_pipeline.this.pipeline_arn
 }
 
 output "ingest_endpoint_urls" {
   description = "The ingestion endpoints for the pipeline that you can send data to"
-  value       = awscc_osis_pipeline.this.ingest_endpoint_urls
+  value       = aws_osis_pipeline.this.ingest_endpoint_urls
 }

--- a/modules/ingestion/pipeline/pipeline.tf
+++ b/modules/ingestion/pipeline/pipeline.tf
@@ -1,24 +1,28 @@
-resource "awscc_osis_pipeline" "this" {
+resource "aws_osis_pipeline" "this" {
   pipeline_name               = var.name
   pipeline_configuration_body = var.configuration_body
 
-  vpc_options = local.vpc_options
-  min_units   = var.min_units
-  max_units   = var.max_units
+  min_units = var.min_units
+  max_units = var.max_units
 
-  log_publishing_options = {
+  vpc_options {
+    subnet_ids         = var.subnet_ids
+    security_group_ids = var.security_group_ids
+  }
+
+  log_publishing_options {
     is_logging_enabled = var.enable_logging
 
-    cloudwatch_log_destination = {
+    cloudwatch_log_destination {
       log_group = local.pipeline_log_group
     }
   }
 
-  buffer_options = {
+  buffer_options {
     persistent_buffer_enabled = var.persistent_buffer_enabled
   }
 
-  tags = local.pipeline_tags
+  tags = var.tags
 
   depends_on = [
     aws_cloudwatch_log_group.this,

--- a/modules/ingestion/pipeline/pipeline.tf
+++ b/modules/ingestion/pipeline/pipeline.tf
@@ -5,16 +5,24 @@ resource "aws_osis_pipeline" "this" {
   min_units = var.min_units
   max_units = var.max_units
 
-  vpc_options {
-    subnet_ids         = var.subnet_ids
-    security_group_ids = var.security_group_ids
+  dynamic "vpc_options" {
+    for_each = length(var.subnet_ids) > 0 ? [1] : []
+
+    content {
+      subnet_ids         = var.subnet_ids
+      security_group_ids = var.security_group_ids
+    }
   }
 
   log_publishing_options {
     is_logging_enabled = var.enable_logging
 
-    cloudwatch_log_destination {
-      log_group = local.pipeline_log_group
+    dynamic "cloudwatch_log_destination" {
+      for_each = var.enable_logging ? [1] : []
+
+      content {
+        log_group = local.pipeline_log_group
+      }
     }
   }
 

--- a/modules/ingestion/pipeline/variables.tf
+++ b/modules/ingestion/pipeline/variables.tf
@@ -32,13 +32,13 @@ variable "enable_logging" {
 variable "subnet_ids" {
   description = "Subnet IDs to deploy pipeline in. Only needed if pipeline is to be deployed in VPC mode"
   type        = list(string)
-  default     = null
+  default     = []
 }
 
 variable "security_group_ids" {
   description = "Security group IDs to attach to the pipeline"
   type        = list(string)
-  default     = null
+  default     = []
 }
 
 variable "persistent_buffer_enabled" {

--- a/modules/ingestion/pipeline/variables.tf
+++ b/modules/ingestion/pipeline/variables.tf
@@ -32,13 +32,13 @@ variable "enable_logging" {
 variable "subnet_ids" {
   description = "Subnet IDs to deploy pipeline in. Only needed if pipeline is to be deployed in VPC mode"
   type        = list(string)
-  default     = []
+  default     = null
 }
 
 variable "security_group_ids" {
   description = "Security group IDs to attach to the pipeline"
   type        = list(string)
-  default     = []
+  default     = null
 }
 
 variable "persistent_buffer_enabled" {

--- a/modules/ingestion/pipeline/versions.tf
+++ b/modules/ingestion/pipeline/versions.tf
@@ -4,11 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.38"
-    }
-    awscc = {
-      source  = "hashicorp/awscc"
-      version = ">= 0.67"
+      version = ">= 5.36"
     }
   }
 }


### PR DESCRIPTION
Migration of Opensearch ingestion pipeline resource from AWSCC to AWS TF provider.

References:
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/osis_pipeline