### PR TITLE
feat: opensearch vpc endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.38 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.13 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.38 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.13 |
 
 ## Modules
 
@@ -28,11 +28,14 @@ No modules.
 | [aws_opensearch_domain.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearch_domain) | resource |
 | [aws_opensearch_domain_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearch_domain_policy) | resource |
 | [aws_opensearch_domain_saml_options.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearch_domain_saml_options) | resource |
+| [aws_opensearch_vpc_endpoint.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearch_vpc_endpoint) | resource |
 | [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.aos_access_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.aos_log_publishing](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
+| [aws_subnet.vpc_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+| [aws_vpc_endpoint.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc_endpoint) | data source |
 
 ## Inputs
 
@@ -48,6 +51,7 @@ No modules.
 | <a name="input_cloudwatch_log_group_retention_days"></a> [cloudwatch\_log\_group\_retention\_days](#input\_cloudwatch\_log\_group\_retention\_days) | Cloudwatch log group retention period in days | `number` | `7` | no |
 | <a name="input_cold_storage_enabled"></a> [cold\_storage\_enabled](#input\_cold\_storage\_enabled) | Enable cold storage. Master and ultrawarm nodes must be enabled for cold storage. | `bool` | `false` | no |
 | <a name="input_create_service_role"></a> [create\_service\_role](#input\_create\_service\_role) | Indicates whether to create the service-linked role. See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/slr.html | `bool` | `false` | no |
+| <a name="input_create_vpc_endpoint"></a> [create\_vpc\_endpoint](#input\_create\_vpc\_endpoint) | Whether to create a VPC endpoint for the domain | `bool` | `false` | no |
 | <a name="input_custom_endpoint"></a> [custom\_endpoint](#input\_custom\_endpoint) | Custom Endpoint URL | `string` | `null` | no |
 | <a name="input_custom_endpoint_certificate_arn"></a> [custom\_endpoint\_certificate\_arn](#input\_custom\_endpoint\_certificate\_arn) | Custom Endpoint Certificate ARN | `string` | `null` | no |
 | <a name="input_custom_endpoint_enabled"></a> [custom\_endpoint\_enabled](#input\_custom\_endpoint\_enabled) | custom endpoint enabled | `bool` | `false` | no |
@@ -89,6 +93,8 @@ No modules.
 | <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | List of VPC Security Group IDs to be applied to the OpenSearch domain endpoints. If omitted, the default Security Group for the VPC will be used | `list(string)` | `[]` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | List of VPC Subnet IDs for the OpenSearch domain endpoints to be created in | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources. | `map(string)` | `{}` | no |
+| <a name="input_vpc_endpoint_security_group_ids"></a> [vpc\_endpoint\_security\_group\_ids](#input\_vpc\_endpoint\_security\_group\_ids) | Security group IDs to use for VPC endpoint | `list(string)` | `[]` | no |
+| <a name="input_vpc_endpoint_subnet_ids"></a> [vpc\_endpoint\_subnet\_ids](#input\_vpc\_endpoint\_subnet\_ids) | Subnet IDs to use for VPC endpoint | `list(string)` | `[]` | no |
 | <a name="input_warm_instance_count"></a> [warm\_instance\_count](#input\_warm\_instance\_count) | The number of dedicated warm nodes in the cluster. | `number` | `3` | no |
 | <a name="input_warm_instance_enabled"></a> [warm\_instance\_enabled](#input\_warm\_instance\_enabled) | Indicates whether ultrawarm nodes are enabled for the cluster. | `bool` | `false` | no |
 | <a name="input_warm_instance_type"></a> [warm\_instance\_type](#input\_warm\_instance\_type) | The type of EC2 instances to run for each warm node. A list of available instance types can you find at https://aws.amazon.com/en/elasticsearch-service/pricing/#UltraWarm_pricing | `string` | `"ultrawarm1.medium.search"` | no |
@@ -96,9 +102,11 @@ No modules.
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_domain_arn"></a> [domain\_arn](#output\_domain\_arn) | ARN of the OpenSearch Cluster |
-| <a name="output_domain_endpoint"></a> [domain\_endpoint](#output\_domain\_endpoint) | Domain-specific endpoint used to submit index, search, and data upload requests |
-| <a name="output_domain_id"></a> [domain\_id](#output\_domain\_id) | Unique identifier for the Cluster |
-| <a name="output_domain_name"></a> [domain\_name](#output\_domain\_name) | Name of the OpenSearch Cluster |
+| Name                                                                                                         | Description                                                                     |
+|--------------------------------------------------------------------------------------------------------------|---------------------------------------------------------------------------------|
+| <a name="output_domain_arn"></a> [domain\_arn](#output\_domain\_arn)                                         | ARN of the OpenSearch Cluster                                                   |
+| <a name="output_domain_endpoint"></a> [domain\_endpoint](#output\_domain\_endpoint)                          | Domain-specific endpoint used to submit index, search, and data upload requests |
+| <a name="output_domain_id"></a> [domain\_id](#output\_domain\_id)                                            | Unique identifier for the Cluster                                               |
+| <a name="output_domain_name"></a> [domain\_name](#output\_domain\_name)                                      | Name of the OpenSearch Cluster                                                  |
+| <a name="output_vpc_endpoint_dns_names"></a> [vpc\_endpoint\_dns\_names](#output\_vpc\_endpoint\_dns\_names) | VPC endpoint DNS names                                                          |
+| <a name="output_vpc_endpoint_id"></a> [vpc\_endpoint\_id](#output\_vpc\_endpoint\_id)                        | VPC endpoint ID                                                                 |

--- a/data.tf
+++ b/data.tf
@@ -3,3 +3,18 @@ data "aws_caller_identity" "current" {
 
 data "aws_region" "current" {
 }
+
+data "aws_subnet" "vpc_endpoint" {
+  count = var.create_vpc_endpoint ? 1 : 0
+  id    = try(var.vpc_endpoint_subnet_ids[0], "")
+}
+
+data "aws_vpc_endpoint" "this" {
+  count = var.create_vpc_endpoint ? 1 : 0
+
+  vpc_id = data.aws_subnet.vpc_endpoint[0].vpc_id
+  tags = {
+    "OpenSearchManaged"       = "true"
+    "OpenSearchVPCEndpointId" = aws_opensearch_vpc_endpoint.this[0].id
+  }
+}

--- a/examples/opensearch/main.tf
+++ b/examples/opensearch/main.tf
@@ -43,6 +43,16 @@ module "opensearch" {
     data.aws_cloudformation_export.app_sg_id.value,
   ]
 
+  # VPC endpoint creation. Disabled by default
+  create_vpc_endpoint = true
+  vpc_endpoint_subnet_ids = [
+    data.aws_cloudformation_export.web_subnet_a.value,
+    data.aws_cloudformation_export.web_subnet_b.value,
+  ]
+  vpc_endpoint_security_group_ids = [
+    data.aws_cloudformation_export.app_sg_id.value,
+  ]
+
   node_to_node_encryption_enabled = true
   encrypt_at_rest_enabled         = true
   encrypt_kms_key_id              = aws_kms_key.objects.id

--- a/main.tf
+++ b/main.tf
@@ -144,4 +144,9 @@ resource "aws_opensearch_vpc_endpoint" "this" {
     subnet_ids         = var.vpc_endpoint_subnet_ids
     security_group_ids = var.vpc_endpoint_security_group_ids
   }
+
+  tags = merge(
+    { Name : "${var.domain_name}-vpce" },
+    var.tags
+  )
 }

--- a/main.tf
+++ b/main.tf
@@ -134,3 +134,14 @@ resource "aws_opensearch_domain_saml_options" "this" {
     }
   }
 }
+
+resource "aws_opensearch_vpc_endpoint" "this" {
+  count = var.create_vpc_endpoint ? 1 : 0
+
+  domain_arn = aws_opensearch_domain.this.arn
+
+  vpc_options {
+    subnet_ids         = var.vpc_endpoint_subnet_ids
+    security_group_ids = var.vpc_endpoint_security_group_ids
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -144,9 +144,4 @@ resource "aws_opensearch_vpc_endpoint" "this" {
     subnet_ids         = var.vpc_endpoint_subnet_ids
     security_group_ids = var.vpc_endpoint_security_group_ids
   }
-
-  tags = merge(
-    { Name : "${var.domain_name}-vpce" },
-    var.tags
-  )
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -17,3 +17,13 @@ output "domain_endpoint" {
   description = "Domain-specific endpoint used to submit index, search, and data upload requests"
   value       = aws_opensearch_domain.this.endpoint
 }
+
+output "vpc_endpoint_id" {
+  description = "VPC endpoint ID"
+  value       = var.create_vpc_endpoint ? aws_opensearch_vpc_endpoint.this[0].id : null
+}
+
+output "vpc_endpoint_dns_names" {
+  description = "VPC endpoint DNS names"
+  value       = var.create_vpc_endpoint ? [for entry in data.aws_vpc_endpoint.this[0].dns_entry : entry.dns_name] : []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -242,6 +242,24 @@ variable "internal_user_database_enabled" {
   default     = false
 }
 
+variable "create_vpc_endpoint" {
+  description = "Whether to create a VPC endpoint for the domain"
+  type        = bool
+  default     = false
+}
+
+variable "vpc_endpoint_subnet_ids" {
+  description = "Subnet IDs to use for VPC endpoint"
+  type        = list(string)
+  default     = []
+}
+
+variable "vpc_endpoint_security_group_ids" {
+  description = "Security group IDs to use for VPC endpoint"
+  type        = list(string)
+  default     = []
+}
+
 ##########
 ## SAML ##
 ##########

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.38"
+      version = ">= 5.13"
     }
   }
 }


### PR DESCRIPTION
`aws_opensearch_vpc_endpoint` resource is available in AWS provider versions `>= 5.13` so adding this in.

Reference: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearch_vpc_endpoint