### PR TITLE
make kms key optional for pipeline logs

### DIFF
--- a/modules/ingestion/pipeline/README.md
+++ b/modules/ingestion/pipeline/README.md
@@ -13,9 +13,7 @@
 
 ## Modules
 
-| Name | Source | Version |
-|------|--------|---------|
-| <a name="module_cloudwatch_kms_secret"></a> [cloudwatch\_kms\_secret](#module\_cloudwatch\_kms\_secret) | SPHTech-Platform/kms/aws | ~> 0.1.0 |
+No modules.
 
 ## Resources
 
@@ -35,17 +33,18 @@
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_configuration_body"></a> [configuration\_body](#input\_configuration\_body) | The Data Prepper pipeline configuration in YAML format | `string` | n/a     | yes |
-| <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | If true, will create a cloudwatch log group to monitor the pipeline | `bool` | `true`  | no |
-| <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name of the pipeline IAM role | `string` | n/a     | yes |
-| <a name="input_log_group_retention_days"></a> [log\_group\_retention\_days](#input\_log\_group\_retention\_days) | Duration in days for cloudwatch log group retention | `number` | `30`    | no |
-| <a name="input_max_units"></a> [max\_units](#input\_max\_units) | The maximum pipeline capacity, in Ingestion Compute Units | `number` | n/a     | yes |
-| <a name="input_min_units"></a> [min\_units](#input\_min\_units) | The minimum pipeline capacity, in Ingestion Compute Units | `number` | n/a     | yes |
-| <a name="input_name"></a> [name](#input\_name) | Name of the ingestion pipeline | `string` | n/a     | yes |
+| <a name="input_cloudwatch_kms_key_id"></a> [cloudwatch\_kms\_key\_id](#input\_cloudwatch\_kms\_key\_id) | (Optional) Use a custom KMS key ID to encrypt Cloudwatch logs. If not specified, then it defaults to using the AWS KMS key. | `string` | `""` | no |
+| <a name="input_configuration_body"></a> [configuration\_body](#input\_configuration\_body) | The Data Prepper pipeline configuration in YAML format | `string` | n/a | yes |
+| <a name="input_enable_logging"></a> [enable\_logging](#input\_enable\_logging) | If true, will create a cloudwatch log group to monitor the pipeline | `bool` | `true` | no |
+| <a name="input_iam_role_name"></a> [iam\_role\_name](#input\_iam\_role\_name) | Name of the pipeline IAM role | `string` | n/a | yes |
+| <a name="input_log_group_retention_days"></a> [log\_group\_retention\_days](#input\_log\_group\_retention\_days) | Duration in days for cloudwatch log group retention | `number` | `30` | no |
+| <a name="input_max_units"></a> [max\_units](#input\_max\_units) | The maximum pipeline capacity, in Ingestion Compute Units | `number` | n/a | yes |
+| <a name="input_min_units"></a> [min\_units](#input\_min\_units) | The minimum pipeline capacity, in Ingestion Compute Units | `number` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Name of the ingestion pipeline | `string` | n/a | yes |
 | <a name="input_persistent_buffer_enabled"></a> [persistent\_buffer\_enabled](#input\_persistent\_buffer\_enabled) | Whether persistent buffering should be enabled | `bool` | `false` | no |
-| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Security group IDs to attach to the pipeline | `list(string)` | `[]`    | no |
-| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to deploy pipeline in. Only needed if pipeline is to be deployed in VPC mode | `list(string)` | `[]`    | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}`    | no |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids) | Security group IDs to attach to the pipeline | `list(string)` | `[]` | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | Subnet IDs to deploy pipeline in. Only needed if pipeline is to be deployed in VPC mode | `list(string)` | `[]` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to add to all resources | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/modules/ingestion/pipeline/cloudwatch.tf
+++ b/modules/ingestion/pipeline/cloudwatch.tf
@@ -1,4 +1,5 @@
 resource "aws_cloudwatch_log_group" "this" {
+  #checkov:skip=CKV_AWS_158:Ensure that CloudWatch Log Group is encrypted by KMS
   #checkov:skip=CKV_AWS_338:Ensure that CloudWatch Log Group specifies retention days
   count = var.enable_logging ? 1 : 0
 

--- a/modules/ingestion/pipeline/cloudwatch.tf
+++ b/modules/ingestion/pipeline/cloudwatch.tf
@@ -3,18 +3,8 @@ resource "aws_cloudwatch_log_group" "this" {
   count = var.enable_logging ? 1 : 0
 
   name              = local.pipeline_log_group
-  kms_key_id        = try(module.cloudwatch_kms_secret[0].key_arn, "")
+  kms_key_id        = var.cloudwatch_kms_key_id
   retention_in_days = var.log_group_retention_days
 
   tags = var.tags
-}
-
-module "cloudwatch_kms_secret" {
-  source  = "SPHTech-Platform/kms/aws"
-  version = "~> 0.1.0"
-  count   = var.enable_logging ? 1 : 0
-
-  key_description       = "Encrypt cloudwatch log group for ${var.name}"
-  alias                 = "alias/${join("-", [var.name, "key"])}"
-  key_policy_statements = [data.aws_iam_policy_document.cloudwatch_log_group.json]
 }

--- a/modules/ingestion/pipeline/data.tf
+++ b/modules/ingestion/pipeline/data.tf
@@ -2,38 +2,6 @@ data "aws_region" "current" {}
 
 data "aws_caller_identity" "current" {}
 
-data "aws_default_tags" "this" {}
-
-data "aws_iam_policy_document" "cloudwatch_log_group" {
-  #checkov:skip=CKV_AWS_283=Ensure no IAM policies documents allow ALL or any AWS principal permissions to the resource
-  #checkov:skip=CKV_AWS_111=Ensure IAM policies does not allow write access without constraints
-  #checkov:skip=CKV_AWS_356:Ensure IAM policies limit resource access
-  statement {
-    sid = "AllowKmsAccess"
-
-    principals {
-      type = "AWS"
-      identifiers = [
-        "*"
-      ]
-    }
-
-    actions = [
-      "kms:Encrypt*",
-      "kms:Decrypt*",
-      "kms:ReEncrypt*",
-      "kms:GenerateDataKey*",
-      "kms:Describe*"
-    ]
-    resources = ["*"]
-    condition {
-      test     = "ArnLike"
-      variable = "kms:EncryptionContext:aws:logs:arn"
-      values   = ["arn:aws:logs:${local.region}:${local.account_id}:log-group:${local.pipeline_log_group}"]
-    }
-  }
-}
-
 data "aws_iam_policy_document" "pipeline_cloudwatch" {
   #checkov:skip=CKV_AWS_283=Ensure no IAM policies documents allow ALL or any AWS principal permissions to the resource
   #checkov:skip=CKV_AWS_111=Ensure IAM policies does not allow write access without constraints

--- a/modules/ingestion/pipeline/pipeline.tf
+++ b/modules/ingestion/pipeline/pipeline.tf
@@ -34,6 +34,5 @@ resource "aws_osis_pipeline" "this" {
 
   depends_on = [
     aws_cloudwatch_log_group.this,
-    module.cloudwatch_kms_secret,
   ]
 }

--- a/modules/ingestion/pipeline/variables.tf
+++ b/modules/ingestion/pipeline/variables.tf
@@ -29,6 +29,12 @@ variable "enable_logging" {
   default     = true
 }
 
+variable "cloudwatch_kms_key_id" {
+  description = "(Optional) Use a custom KMS key ID to encrypt Cloudwatch logs. If not specified, then it defaults to using the AWS KMS key."
+  type        = string
+  default     = ""
+}
+
 variable "subnet_ids" {
   description = "Subnet IDs to deploy pipeline in. Only needed if pipeline is to be deployed in VPC mode"
   type        = list(string)

--- a/modules/ingestion/pipeline/variables.tf
+++ b/modules/ingestion/pipeline/variables.tf
@@ -30,9 +30,9 @@ variable "enable_logging" {
 }
 
 variable "cloudwatch_kms_key_id" {
-  description = "(Optional) Use a custom KMS key ID to encrypt Cloudwatch logs. If not specified, then it defaults to using the AWS KMS key."
+  description = "(Optional) KMS key ID for Cloudwatch logs"
   type        = string
-  default     = ""
+  default     = null
 }
 
 variable "subnet_ids" {


### PR DESCRIPTION
Making KMS key encryption optional for ingestion pipeline. Use AWS owned key by default