### PR TITLE
feat: multi-tenancy support for dashboard objects

### DIFF
--- a/modules/dashboard/index-pattern/README.md
+++ b/modules/dashboard/index-pattern/README.md
@@ -1,16 +1,15 @@
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
-| <a name="requirement_opensearch"></a> [opensearch](#requirement\_opensearch) | >= 1.0 |
+| <a name="requirement_opensearch"></a> [opensearch](#requirement\_opensearch) | >= 2.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_opensearch"></a> [opensearch](#provider\_opensearch) | 2.2.1 |
+| <a name="provider_opensearch"></a> [opensearch](#provider\_opensearch) | >= 2.3 |
 
 ## Modules
 
@@ -28,6 +27,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_pattern"></a> [pattern](#input\_pattern) | The index pattern | `string` | n/a | yes |
 | <a name="input_pattern_id"></a> [pattern\_id](#input\_pattern\_id) | The ID of index pattern | `string` | `null` | no |
+| <a name="input_tenant_name"></a> [tenant\_name](#input\_tenant\_name) | The name of the tenant to which dashboard data associates. Empty string defaults to global tenant | `string` | `""` | no |
 | <a name="input_time_field_name"></a> [time\_field\_name](#input\_time\_field\_name) | Field name which has the timestamp | `string` | n/a | yes |
 
 ## Outputs
@@ -35,4 +35,3 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_id"></a> [id](#output\_id) | The ID of the index pattern |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/dashboard/index-pattern/main.tf
+++ b/modules/dashboard/index-pattern/main.tf
@@ -3,7 +3,8 @@ locals {
 }
 
 resource "opensearch_dashboard_object" "index_pattern" {
-  body = <<EOF
+  tenant_name = var.tenant_name
+  body        = <<EOF
 [
   {
     "_id": "index-pattern:${local.id}",

--- a/modules/dashboard/index-pattern/variables.tf
+++ b/modules/dashboard/index-pattern/variables.tf
@@ -13,3 +13,9 @@ variable "time_field_name" {
   description = "Field name which has the timestamp"
   type        = string
 }
+
+variable "tenant_name" {
+  description = "The name of the tenant to which dashboard data associates. Empty string defaults to global tenant"
+  type        = string
+  default     = ""
+}

--- a/modules/dashboard/index-pattern/versions.tf
+++ b/modules/dashboard/index-pattern/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     opensearch = {
       source  = "opensearch-project/opensearch"
-      version = ">= 1.0"
+      version = ">= 2.3"
     }
   }
 }


### PR DESCRIPTION
Opensearch provider `v2.3` now supports multi-tenancy when creating dashboard objects. We can use this to create index patterns in individual tenants.

References:
- https://github.com/opensearch-project/terraform-provider-opensearch/releases/tag/v2.3.0
- https://github.com/opensearch-project/terraform-provider-opensearch/pull/184