### PR TITLE
feat: slack channel and monitor submodules

### DIFF
--- a/examples/notification/main.tf
+++ b/examples/notification/main.tf
@@ -9,71 +9,79 @@ module "slack_channel" {
 module "monitor" {
   source = "../../modules/monitor"
 
-  body = <<EOF
-{
-  "name": "test-monitor",
-  "type": "monitor",
-  "enabled": true,
-  "schedule": {
-    "period": {
-      "interval": 1,
-      "unit": "MINUTES"
+  body = {
+    name    = "test-monitor"
+    type    = "monitor"
+    enabled = true
+
+    schedule = {
+      period = {
+        interval = 1
+        unit     = "MINUTES"
+      }
     }
-  },
-  "inputs": [{
-    "search": {
-      "indices": ["movies"],
-      "query": {
-        "size": 0,
-        "aggregations": {},
-        "query": {
-          "bool": {
-            "adjust_pure_negative":true,
-            "boost":1,
-            "filter": [{
-              "range": {
-                "@timestamp": {
-                  "boost":1,
-                  "from":"||-1h",
-                  "to":"",
-                  "include_lower":true,
-                  "include_upper":true,
-                  "format": "epoch_millis"
-                }
+
+    inputs = [
+      {
+        search = {
+          indices = ["movies"]
+          query = {
+            size         = 0
+            aggregations = {}
+            query = {
+              bool = {
+                adjust_pure_negative = true
+                boost                = 1
+
+                filter = [
+                  {
+                    range = {
+                      "@timestamp" = {
+                        boost         = 1
+                        from          = "||-1h"
+                        to            = ""
+                        include_lower = true
+                        include_upper = true
+                        format        = "epoch_millis"
+                      }
+                    }
+                  }
+                ]
               }
-            }]
+            }
           }
         }
       }
-    }
-  }],
-  "triggers": [
-    {
-      "name" : "Errors",
-      "severity" : "1",
-      "condition" : {
-        "script" : {
-          "source" : "ctx.results[0].hits.total.value > 0",
-          "lang" : "painless"
-        }
-      },
-      "actions" : [
-        {
-          "name" : "Slack",
-          "destination_id" : "${module.slack_channel.id}",
-          "message_template" : {
-            "source" : "bogus",
-            "lang" : "mustache"
-          },
-          "throttle_enabled" : false,
-          "subject_template" : {
-            "source" : "Production Errors",
-            "lang" : "mustache"
+    ]
+
+    triggers = [
+      {
+        name     = "Errors"
+        severity = "1"
+
+        condition = {
+          script = {
+            source = "ctx.results[0].hits.total.value > 0"
+            lang   = "painless"
           }
         }
-      ]
-    }
-  ]
-}
-EOF
+
+        actions = [
+          {
+            name             = "Slack"
+            destination_id   = module.slack_channel.id
+            throttle_enabled = false
+            message_template = {
+              source = "bogus"
+              lang   = "mustache"
+            }
+            subject_template = {
+              source = "Production Errors"
+              lang   = "mustache"
+            }
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/examples/notification/main.tf
+++ b/examples/notification/main.tf
@@ -1,0 +1,79 @@
+module "slack_channel" {
+  source = "../../modules/channel/slack"
+
+  id          = "test_slack"
+  name        = "Test slack channel"
+  webhook_url = "https://hooks.slack.com/services/test"
+}
+
+module "monitor" {
+  source = "../../modules/monitor"
+
+  body = <<EOF
+{
+  "name": "test-monitor",
+  "type": "monitor",
+  "enabled": true,
+  "schedule": {
+    "period": {
+      "interval": 1,
+      "unit": "MINUTES"
+    }
+  },
+  "inputs": [{
+    "search": {
+      "indices": ["movies"],
+      "query": {
+        "size": 0,
+        "aggregations": {},
+        "query": {
+          "bool": {
+            "adjust_pure_negative":true,
+            "boost":1,
+            "filter": [{
+              "range": {
+                "@timestamp": {
+                  "boost":1,
+                  "from":"||-1h",
+                  "to":"",
+                  "include_lower":true,
+                  "include_upper":true,
+                  "format": "epoch_millis"
+                }
+              }
+            }]
+          }
+        }
+      }
+    }
+  }],
+  "triggers": [
+    {
+      "name" : "Errors",
+      "severity" : "1",
+      "condition" : {
+        "script" : {
+          "source" : "ctx.results[0].hits.total.value > 0",
+          "lang" : "painless"
+        }
+      },
+      "actions" : [
+        {
+          "name" : "Slack",
+          "destination_id" : "${module.slack_channel.id}",
+          "message_template" : {
+            "source" : "bogus",
+            "lang" : "mustache"
+          },
+          "throttle_enabled" : false,
+          "subject_template" : {
+            "source" : "Production Errors",
+            "lang" : "mustache"
+          }
+        }
+      ]
+    }
+  ]
+}
+EOF
+}

--- a/examples/notification/providers.tf
+++ b/examples/notification/providers.tf
@@ -1,0 +1,2 @@
+provider "opensearch" {
+}

--- a/examples/notification/versions.tf
+++ b/examples/notification/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4"
+
+  required_providers {
+    opensearch = {
+      source  = "opensearch-project/opensearch"
+      version = "~> 2.3.0"
+    }
+  }
+}

--- a/modules/channel/slack/README.md
+++ b/modules/channel/slack/README.md
@@ -1,0 +1,37 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
+| <a name="requirement_opensearch"></a> [opensearch](#requirement\_opensearch) | >= 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_opensearch"></a> [opensearch](#provider\_opensearch) | >= 2.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [opensearch_channel_configuration.this](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/channel_configuration) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_description"></a> [description](#input\_description) | Channel config description | `string` | `""` | no |
+| <a name="input_id"></a> [id](#input\_id) | Channel config ID | `string` | n/a | yes |
+| <a name="input_name"></a> [name](#input\_name) | Channel config name | `string` | n/a | yes |
+| <a name="input_webhook_url"></a> [webhook\_url](#input\_webhook\_url) | Slack webhook URL | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | The ID of the channel configuration |

--- a/modules/channel/slack/main.tf
+++ b/modules/channel/slack/main.tf
@@ -1,16 +1,18 @@
 resource "opensearch_channel_configuration" "this" {
-  body = <<EOF
-{
-  "config_id": "${var.id}",
-  "config": {
-    "name": "${var.name}",
-    "description" : "${var.description}",
-    "config_type" : "slack",
-    "is_enabled" : true,
-    "slack": {
-      "url": "${var.webhook_url}"
+  body = jsonencode(
+    {
+      config_id = var.id
+
+      config = {
+        name        = var.name
+        description = var.description
+        config_type = "slack"
+        is_enabled  = true
+
+        slack = {
+          url = var.webhook_url
+        }
+      }
     }
-  }
-}
-EOF
+  )
 }

--- a/modules/channel/slack/main.tf
+++ b/modules/channel/slack/main.tf
@@ -1,0 +1,16 @@
+resource "opensearch_channel_configuration" "this" {
+  body = <<EOF
+{
+  "config_id": "${var.id}",
+  "config": {
+    "name": "${var.name}",
+    "description" : "${var.description}",
+    "config_type" : "slack",
+    "is_enabled" : true,
+    "slack": {
+      "url": "${var.webhook_url}"
+    }
+  }
+}
+EOF
+}

--- a/modules/channel/slack/outputs.tf
+++ b/modules/channel/slack/outputs.tf
@@ -1,0 +1,4 @@
+output "id" {
+  description = "The ID of the channel configuration"
+  value       = opensearch_channel_configuration.this.id
+}

--- a/modules/channel/slack/variables.tf
+++ b/modules/channel/slack/variables.tf
@@ -1,0 +1,20 @@
+variable "name" {
+  description = "Channel config name"
+  type        = string
+}
+
+variable "id" {
+  description = "Channel config ID"
+  type        = string
+}
+
+variable "description" {
+  description = "Channel config description"
+  type        = string
+  default     = ""
+}
+
+variable "webhook_url" {
+  description = "Slack webhook URL"
+  type        = string
+}

--- a/modules/channel/slack/versions.tf
+++ b/modules/channel/slack/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4"
+
+  required_providers {
+    opensearch = {
+      source  = "opensearch-project/opensearch"
+      version = ">= 2.0"
+    }
+  }
+}

--- a/modules/monitor/README.md
+++ b/modules/monitor/README.md
@@ -1,0 +1,34 @@
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
+| <a name="requirement_opensearch"></a> [opensearch](#requirement\_opensearch) | >= 2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_opensearch"></a> [opensearch](#provider\_opensearch) | >= 2.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [opensearch_monitor.this](https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/monitor) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_body"></a> [body](#input\_body) | The monitor document | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_id"></a> [id](#output\_id) | The ID of the monitor |

--- a/modules/monitor/main.tf
+++ b/modules/monitor/main.tf
@@ -1,3 +1,3 @@
 resource "opensearch_monitor" "this" {
-  body = var.body
+  body = jsonencode(var.body)
 }

--- a/modules/monitor/main.tf
+++ b/modules/monitor/main.tf
@@ -1,0 +1,3 @@
+resource "opensearch_monitor" "this" {
+  body = var.body
+}

--- a/modules/monitor/outputs.tf
+++ b/modules/monitor/outputs.tf
@@ -1,0 +1,4 @@
+output "id" {
+  description = "The ID of the monitor"
+  value       = opensearch_monitor.this.id
+}

--- a/modules/monitor/variables.tf
+++ b/modules/monitor/variables.tf
@@ -1,0 +1,4 @@
+variable "body" {
+  description = "The monitor document"
+  type        = string
+}

--- a/modules/monitor/variables.tf
+++ b/modules/monitor/variables.tf
@@ -1,4 +1,4 @@
 variable "body" {
-  description = "The monitor document"
-  type        = string
+  description = "The monitor document in HCL format"
+  type        = any
 }

--- a/modules/monitor/versions.tf
+++ b/modules/monitor/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.4"
+
+  required_providers {
+    opensearch = {
+      source  = "opensearch-project/opensearch"
+      version = ">= 2.0"
+    }
+  }
+}


### PR DESCRIPTION
Submodules for creating slack channels and monitors. 

https://sph.atlassian.net/browse/PFMENG-2237

References:
- https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/channel_configuration
- https://registry.terraform.io/providers/opensearch-project/opensearch/latest/docs/resources/monitor