### PR TITLE
change period for cluster writes blocked

### DIFF
--- a/alarms.tf
+++ b/alarms.tf
@@ -50,7 +50,7 @@ locals {
       comparison_operator = "GreaterThanOrEqualToThreshold"
       evaluation_periods  = 1
       threshold           = 1
-      period              = 5 * local.minute
+      period              = 1 * local.minute
 
       namespace          = "ES/OpenSearchService"
       metric_name        = "ClusterIndexWritesBlocked"


### PR DESCRIPTION
Recommendations for AWS Support:

-- ClusterIndexWritesBlocked is >= 1 for 5 minutes, 1 consecutive time
-- Consider Changing period to 60s (1 Min)
-- Consider Changing DatapointstoAlarm to 5 out 5