### PR TITLE
feat: support coordinator nodes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,18 @@
 repos:
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.23
+    rev: v0.1.26
     hooks:
       - id: shellcheck
 
   - repo: https://github.com/tcort/markdown-link-check
-    rev: v3.12.2
+    rev: v3.13.7
     hooks:
       - id: markdown-link-check
         args:
           - "--config=mlc_config.json"
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.92.0
+    rev: v1.97.4
     hooks:
       - id: terraform_fmt
       - id: terraform_providers_lock
@@ -36,7 +36,7 @@ repos:
           - "--args=--skip-check CKV_TF_1"
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.6.0
+    rev: v5.0.0
     hooks:
       # Git style
       - id: check-added-large-files

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "aws" {
   enabled = true
-  version = "0.32.0"
+  version = "0.38.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/README.md
+++ b/README.md
@@ -3,13 +3,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.16 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.90 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.16 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.90 |
 
 ## Modules
 
@@ -55,6 +55,9 @@
 | <a name="input_cognito_role_arn"></a> [cognito\_role\_arn](#input\_cognito\_role\_arn) | ARN of the IAM role that has the AmazonOpenSearchServiceCognitoAccess policy attached. | `string` | `""` | no |
 | <a name="input_cognito_user_id_pool"></a> [cognito\_user\_id\_pool](#input\_cognito\_user\_id\_pool) | ID of the Cognito User Pool to use. | `string` | `""` | no |
 | <a name="input_cold_storage_enabled"></a> [cold\_storage\_enabled](#input\_cold\_storage\_enabled) | Enable cold storage. Master and ultrawarm nodes must be enabled for cold storage. | `bool` | `false` | no |
+| <a name="input_coordinator_instance_count"></a> [coordinator\_instance\_count](#input\_coordinator\_instance\_count) | The number of coordinator nodes in the cluster. | `number` | `3` | no |
+| <a name="input_coordinator_instance_enabled"></a> [coordinator\_instance\_enabled](#input\_coordinator\_instance\_enabled) | Indicates whether coordinator nodes are enabled for the cluster. | `bool` | `false` | no |
+| <a name="input_coordinator_instance_type"></a> [coordinator\_instance\_type](#input\_coordinator\_instance\_type) | The type of EC2 instances to run for each coordinator node. | `string` | `""` | no |
 | <a name="input_create_alarms"></a> [create\_alarms](#input\_create\_alarms) | Whether to create default set of alarms | `bool` | `true` | no |
 | <a name="input_create_service_role"></a> [create\_service\_role](#input\_create\_service\_role) | Indicates whether to create the service-linked role. See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/slr.html | `bool` | `false` | no |
 | <a name="input_create_vpc_endpoint"></a> [create\_vpc\_endpoint](#input\_create\_vpc\_endpoint) | Whether to create a VPC endpoint for the domain | `bool` | `false` | no |

--- a/examples/opensearch/main.tf
+++ b/examples/opensearch/main.tf
@@ -34,7 +34,7 @@ module "opensearch" {
   ebs_enabled = true
   ebs_iops    = 5000
 
-  # If coordinatyor nodes are need. This is disabled by default
+  # If dedicated coordinator nodes are need. This is disabled by default
   coordinator_instance_enabled = true
   # Coordinator node count must be less than or equal to data node count
   coordinator_instance_count = 2

--- a/examples/opensearch/main.tf
+++ b/examples/opensearch/main.tf
@@ -34,6 +34,12 @@ module "opensearch" {
   ebs_enabled = true
   ebs_iops    = 5000
 
+  # If coordinatyor nodes are need. This is disabled by default
+  coordinator_instance_enabled = true
+  # Coordinator node count must be less than or equal to data node count
+  coordinator_instance_count = 2
+  coordinator_instance_type  = "m5.large.search"
+
   subnet_ids = [
     data.aws_cloudformation_export.web_subnet_a.value,
     data.aws_cloudformation_export.web_subnet_b.value,

--- a/examples/opensearch/versions.tf
+++ b/examples/opensearch/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.3"
+  required_version = ">= 1.4"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.16"
+      version = "~> 5.90"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -27,6 +27,19 @@ resource "aws_opensearch_domain" "this" {
     warm_count   = var.warm_instance_enabled ? var.warm_instance_count : null
     warm_type    = var.warm_instance_enabled ? var.warm_instance_type : null
 
+    dynamic "node_options" {
+      for_each = var.coordinator_instance_enabled ? [1] : []
+
+      content {
+        node_type = "coordinator"
+        node_config {
+          enabled = true
+          type    = var.coordinator_instance_type
+          count   = var.coordinator_instance_count
+        }
+      }
+    }
+
     zone_awareness_enabled = (var.availability_zones > 1) ? true : false
 
     dynamic "zone_awareness_config" {

--- a/variables.tf
+++ b/variables.tf
@@ -150,6 +150,24 @@ variable "cold_storage_enabled" {
   default     = false
 }
 
+variable "coordinator_instance_enabled" {
+  description = "Indicates whether coordinator nodes are enabled for the cluster."
+  type        = bool
+  default     = false
+}
+
+variable "coordinator_instance_type" {
+  description = "The type of EC2 instances to run for each coordinator node."
+  type        = string
+  default     = ""
+}
+
+variable "coordinator_instance_count" {
+  description = "The number of coordinator nodes in the cluster."
+  type        = number
+  default     = 3
+}
+
 variable "availability_zones" {
   description = "The number of availability zones for the OpenSearch cluster. Valid values: 1, 2 or 3."
   type        = number

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.16"
+      version = ">= 5.90"
     }
   }
 }


### PR DESCRIPTION
Support for dedicated coordinator nodes.

References:
- https://docs.aws.amazon.com/opensearch-service/latest/developerguide/Dedicated-coordinator-nodes.html
- https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/opensearch_domain#node_options-1