### PR TITLE
support for aws provider v6 with upstream aws modules upgrade

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/gruntwork-io/pre-commit
-    rev: v0.1.26
+    rev: v0.1.30
     hooks:
       - id: shellcheck
 
@@ -12,7 +12,7 @@ repos:
           - "--config=mlc_config.json"
 
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.97.4
+    rev: v1.100.0
     hooks:
       - id: terraform_fmt
       - id: terraform_providers_lock
@@ -36,7 +36,7 @@ repos:
           - "--args=--skip-check CKV_TF_1"
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       # Git style
       - id: check-added-large-files

--- a/.terraform-docs.yaml
+++ b/.terraform-docs.yaml
@@ -8,8 +8,6 @@ output:
   file: "README.md"
   mode: replace
   template: |-
-    <!-- BEGIN_TF_DOCS -->
     {{ .Content }}
-    <!-- END_TF_DOCS -->
 settings:
   lockfile: false

--- a/.tflint.hcl
+++ b/.tflint.hcl
@@ -1,6 +1,6 @@
 plugin "aws" {
   enabled = true
-  version = "0.38.0"
+  version = "0.42.0"
   source  = "github.com/terraform-linters/tflint-ruleset-aws"
 }
 

--- a/README.md
+++ b/README.md
@@ -1,22 +1,21 @@
-<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.90 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.90 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_cloudwatch_alarms"></a> [cloudwatch\_alarms](#module\_cloudwatch\_alarms) | terraform-aws-modules/cloudwatch/aws//wrappers/metric-alarm | ~> 5.4.0 |
+| <a name="module_cloudwatch_alarms"></a> [cloudwatch\_alarms](#module\_cloudwatch\_alarms) | terraform-aws-modules/cloudwatch/aws//wrappers/metric-alarm | ~> 5.7.0 |
 
 ## Resources
 
@@ -124,4 +123,3 @@
 | <a name="output_vpc_endpoint_dns_names"></a> [vpc\_endpoint\_dns\_names](#output\_vpc\_endpoint\_dns\_names) | VPC endpoint DNS names |
 | <a name="output_vpc_endpoint_endpoint"></a> [vpc\_endpoint\_endpoint](#output\_vpc\_endpoint\_endpoint) | The connection endpoint ID for connecting to the domain |
 | <a name="output_vpc_endpoint_id"></a> [vpc\_endpoint\_id](#output\_vpc\_endpoint\_id) | The unique identifier of the endpoint |
-<!-- END_TF_DOCS -->

--- a/alarms.tf
+++ b/alarms.tf
@@ -474,7 +474,7 @@ locals {
 
 module "cloudwatch_alarms" {
   source  = "terraform-aws-modules/cloudwatch/aws//wrappers/metric-alarm"
-  version = "~> 5.4.0"
+  version = "~> 5.7.0"
 
   items = local.alarms
 }

--- a/examples/ingestion/main.tf
+++ b/examples/ingestion/main.tf
@@ -1,6 +1,6 @@
 locals {
   account_id = data.aws_caller_identity.current.account_id
-  region     = data.aws_region.current.name
+  region     = data.aws_region.current.region
 
   domain_name = "domain"
 

--- a/examples/ingestion/versions.tf
+++ b/examples/ingestion/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.4"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.36"
+      version = "~> 6.0"
     }
   }
 }

--- a/examples/opensearch/versions.tf
+++ b/examples/opensearch/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.4"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.90"
+      version = "~> 6.0"
     }
   }
 }

--- a/iam.tf
+++ b/iam.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "aos_access_policy" {
 
     actions = ["es:*"]
 
-    resources = ["arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/*"]
+    resources = ["arn:aws:es:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/*"]
   }
 
   dynamic "statement" {
@@ -35,7 +35,7 @@ data "aws_iam_policy_document" "aos_access_policy" {
 
       actions = ["es:ESHttp*"]
 
-      resources = ["arn:aws:es:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/*"]
+      resources = ["arn:aws:es:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:domain/${var.domain_name}/*"]
 
       condition {
         test     = "IpAddress"

--- a/modules/ingestion/iam/README.md
+++ b/modules/ingestion/iam/README.md
@@ -1,23 +1,22 @@
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.38 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.46.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 4.67.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_pipeline_opensearch_policy"></a> [pipeline\_opensearch\_policy](#module\_pipeline\_opensearch\_policy) | terraform-aws-modules/iam/aws//modules/iam-policy | ~> 5.5.0 |
-| <a name="module_pipeline_role"></a> [pipeline\_role](#module\_pipeline\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | ~> 5.5.0 |
+| <a name="module_pipeline_opensearch_policy"></a> [pipeline\_opensearch\_policy](#module\_pipeline\_opensearch\_policy) | terraform-aws-modules/iam/aws//modules/iam-policy | ~> 5.60.0 |
+| <a name="module_pipeline_role"></a> [pipeline\_role](#module\_pipeline\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role | ~> 5.60.0 |
 
 ## Resources
 
@@ -40,4 +39,3 @@
 | <a name="output_opensearch_ingestion_policy_arn"></a> [opensearch\_ingestion\_policy\_arn](#output\_opensearch\_ingestion\_policy\_arn) | ARN of the Opensearch ingestion policy |
 | <a name="output_pipeline_role_arn"></a> [pipeline\_role\_arn](#output\_pipeline\_role\_arn) | ARN of the Opensearch ingestion pipeline role |
 | <a name="output_pipeline_role_name"></a> [pipeline\_role\_name](#output\_pipeline\_role\_name) | Name of the Opensearch ingestion pipeline role |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ingestion/iam/iam.tf
+++ b/modules/ingestion/iam/iam.tf
@@ -1,6 +1,6 @@
 module "pipeline_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
-  version = "~> 5.5.0"
+  version = "~> 5.60.0"
 
   create_role      = true
   role_name        = var.pipeline_role_name
@@ -17,7 +17,7 @@ module "pipeline_role" {
 
 module "pipeline_opensearch_policy" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "~> 5.5.0"
+  version = "~> 5.60.0"
 
   create_policy = local.create_opensearch_ingestion_policy
 

--- a/modules/ingestion/iam/versions.tf
+++ b/modules/ingestion/iam/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.4"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {

--- a/modules/ingestion/pipeline/README.md
+++ b/modules/ingestion/pipeline/README.md
@@ -1,16 +1,15 @@
-<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.36 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.10 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.46.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.36.0 |
 
 ## Modules
 
@@ -52,4 +51,3 @@ No modules.
 | <a name="output_arn"></a> [arn](#output\_arn) | ARN of the ingestion pipeline |
 | <a name="output_id"></a> [id](#output\_id) | ID of the ingestion pipeline |
 | <a name="output_ingest_endpoint_urls"></a> [ingest\_endpoint\_urls](#output\_ingest\_endpoint\_urls) | The ingestion endpoints for the pipeline that you can send data to |
-<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/ingestion/pipeline/locals.tf
+++ b/modules/ingestion/pipeline/locals.tf
@@ -1,6 +1,6 @@
 locals {
   account_id = data.aws_caller_identity.current.account_id
-  region     = data.aws_region.current.name
+  region     = data.aws_region.current.region
 
   pipeline_log_group = "/aws/vendedlogs/OpenSearchIngestion/${var.name}/audit-logs"
 }

--- a/modules/ingestion/pipeline/versions.tf
+++ b/modules/ingestion/pipeline/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.4"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.36"
+      version = ">= 6.0"
     }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,10 +1,10 @@
 terraform {
-  required_version = ">= 1.4"
+  required_version = ">= 1.10"
 
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.90"
+      version = ">= 6.0"
     }
   }
 }


### PR DESCRIPTION
-  Support for AWS provider v6
- Upgrading upstream AWS modules
- Updated pre-commit hooks