### PR TITLE
fix: add ClientId dimension to all OpenSearch alarms (PES-2423)

### DIFF
--- a/alarms.tf
+++ b/alarms.tf
@@ -42,6 +42,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -87,6 +88,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -112,6 +114,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -135,6 +138,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -159,6 +163,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -184,6 +189,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -207,6 +213,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -230,6 +237,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -253,6 +261,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -276,6 +285,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -301,6 +311,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -325,6 +336,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -348,6 +360,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -371,6 +384,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -393,6 +407,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -415,6 +430,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -439,6 +455,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions
@@ -462,6 +479,7 @@ locals {
 
       dimensions = {
         DomainName = aws_opensearch_domain.this.domain_name
+        ClientId   = data.aws_caller_identity.current.account_id
       }
       alarm_actions             = var.alarm_actions
       ok_actions                = var.ok_actions


### PR DESCRIPTION
Jira: [PES-2423](https://sph.atlassian.net/browse/PES-2423)

## Problem

OpenSearch publishes every `AWS/ES` domain-level metric under the **Per-Domain, Per-Client Metrics** dimension set (`ClientId` + `DomainName`), and instance/warm metrics under `ClientId, DomainName[, NodeId]`. There is no `DomainName`-only dimension set, and a CloudWatch alarm only matches an exact dimension set.

18 of the 20 alarms in `alarms.tf` specified `DomainName` alone, so they matched no metric stream. Because most of them use `treat_missing_data = "notBreaching"`, they sat permanently in `OK` instead of alerting — the alarms existed but could never fire.

## Change

Added `ClientId = data.aws_caller_identity.current.account_id` to the `dimensions` of every alarm that was missing it.

Already correct: `cluster_status_red`, `cluster_writes_blocked`

Fixed: `cluster_status_yellow`, `unreachable_nodes`, `data_high_cpu_utilization`, `master_high_cpu_utilization`, `warm_high_cpu_utilization`, `data_high_jvm_pressure`, `data_high_oldjvm_pressure`, `master_high_jvm_pressure`, `master_high_oldjvm_pressure`, `free_storage_space`, `aos_key_error`, `aos_key_inaccessible`, `server_errors`, `threadpool_high_write_avg`, `threadpool_high_search_avg`, `threadpool_high_search_max`, `hot_to_warm_migration_failure`, `warm_to_hot_migration_queue`

## Impact

Existing deployments will see an in-place update on those 18 alarms. Expect some to flip out of a false `OK` once they start receiving real data — worth reviewing thresholds on `free_storage_space` and the threadpool alarms after rollout.

## Testing

`terraform fmt -check` passes. Not plan-verified (no AWS credentials in the authoring environment).

Ref: [Monitoring OpenSearch cluster metrics with Amazon CloudWatch](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/managedomains-cloudwatchmetrics.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[PES-2423]: https://sph.atlassian.net/browse/PES-2423?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ